### PR TITLE
Regex updates, env updates and logging additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.1.5 - 2023-09
+
+### Added
+
+- Better handling of default environment when creating filename. See [ssue #54](https://github.com/weareferal/craft-remote-sync/issues/54).
+
 ## 4.1.0 - 2022-10-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 4.1.1 - 2023-09
+## 4.2.0 - 2023-09-29
 
 ### Fixed
 
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 
 - Better handling of default environment when creating filename. See [Issue #54](https://github.com/weareferal/craft-remote-sync/issues/54).
+- Additional logging to help with debugging user issues.
 
 ## 4.1.0 - 2022-10-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 4.2.0 - 2023-09-29
+## 4.1.1 - 2023-09-29
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 4.1.5 - 2023-09
+## 4.1.1 - 2023-09
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## 4.1.1 - 2023-09
 
+### Fixed
+
+- Updated the regex for filenames to include ' and _ (occasionally included in system names). See [Issue #19](https://github.com/weareferal/craft-remote-core/issues/19).
+
 ### Added
 
-- Better handling of default environment when creating filename. See [ssue #54](https://github.com/weareferal/craft-remote-sync/issues/54).
+- Better handling of default environment when creating filename. See [Issue #54](https://github.com/weareferal/craft-remote-sync/issues/54).
 
 ## 4.1.0 - 2022-10-05
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ This module is used by `craft-remote-backup` and `create-remote-sync` for shared
 
 - AWS
 - Google Drive
-- Dropbox
 - Digital Ocean
 - Backblaze
 

--- a/src/helpers/RemoteFile.php
+++ b/src/helpers/RemoteFile.php
@@ -31,7 +31,7 @@ class RemoteFile
     //
     // https://regex101.com/r/yyAtKC/3
     private static $legacyRegex = '/^(?:[a-zA-Z0-9\-]+)\_(?:([a-zA-Z0-9\-]+)\_)?(\d{6}\_\d{6})\_(?:[a-zA-Z0-9]+)\_(?:([va-zA-Z0-9\.\-]+))\.(?:\w{2,10})$/';
-    private static $regex = '/^(?:[a-zA-Z0-9\_\-\']+)\_\_(?:([a-zA-Z0-9\-]+)\_\_)?(\d{6}\_\d{6})\_\_(?:[a-zA-Z0-9]+)\_\_(?:([va-zA-Z0-9\.\-]+))\.(?:\w{2,10})$/';
+    private static $regex = '/^(?:[a-zA-Z0-9\_\-\']+)\_\_([a-zA-Z0-9\-]+)\_\_(\d{6}\_\d{6})\_\_(?:[a-zA-Z0-9]+)\_\_([va-zA-Z0-9\.\-]+)\.(?:\w{2,10})/';
 
     public function __construct($filename, $size)
     {

--- a/src/helpers/RemoteFile.php
+++ b/src/helpers/RemoteFile.php
@@ -9,7 +9,7 @@ use weareferal\remotecore\helpers\TimeHelper;
 
 /**
  * Remote file
- * 
+ *
  * An internal class data-type that helps us extract the relevent remote
  * file information from the file name.
  */
@@ -28,8 +28,10 @@ class RemoteFile
     // - Random string
     // - Version (captured)
     // - Extension
+    //
+    // https://regex101.com/r/yyAtKC/3
     private static $legacyRegex = '/^(?:[a-zA-Z0-9\-]+)\_(?:([a-zA-Z0-9\-]+)\_)?(\d{6}\_\d{6})\_(?:[a-zA-Z0-9]+)\_(?:([va-zA-Z0-9\.\-]+))\.(?:\w{2,10})$/';
-    private static $regex = '/^(?:[a-zA-Z0-9\-]+)\_\_(?:([a-zA-Z0-9\-]+)\_\_)?(\d{6}\_\d{6})\_\_(?:[a-zA-Z0-9]+)\_\_(?:([va-zA-Z0-9\.\-]+))\.(?:\w{2,10})$/';
+    private static $regex = '/^(?:[a-zA-Z0-9\_\-\']+)\_\_(?:([a-zA-Z0-9\-]+)\_\_)?(\d{6}\_\d{6})\_\_(?:[a-zA-Z0-9]+)\_\_(?:([va-zA-Z0-9\.\-]+))\.(?:\w{2,10})$/';
 
     public function __construct($filename, $size)
     {
@@ -45,7 +47,7 @@ class RemoteFile
             $matches[2],
             new DateTimeZone("UTC"));
         $datetime->setTimezone(new DateTimeZone(date_default_timezone_get()));
-        
+
         $this->filename = $filename;
         $this->size = $size;
         $this->datetime = $datetime;
@@ -55,23 +57,23 @@ class RemoteFile
 
     /**
      * Friendly Size
-     * 
+     *
      * A human-readable size of this file
-     * 
+     *
      * https://stackoverflow.com/a/2510459/396300
      */
     protected function friendlySize($precision = 2) {
-        $units = array('B', 'KB', 'MB', 'GB', 'TB'); 
-        $bytes = max($this->size, 0); 
-        $pow = floor(($bytes ? log($bytes) : 0) / log(1024)); 
-        $pow = min($pow, count($units) - 1); 
-        $bytes /= (1 << (10 * $pow)); 
-        return round($bytes, $precision) . ' ' . $units[$pow]; 
-    } 
+        $units = array('B', 'KB', 'MB', 'GB', 'TB');
+        $bytes = max($this->size, 0);
+        $pow = floor(($bytes ? log($bytes) : 0) / log(1024));
+        $pow = min($pow, count($units) - 1);
+        $bytes /= (1 << (10 * $pow));
+        return round($bytes, $precision) . ' ' . $units[$pow];
+    }
 
     /**
      * Sort
-     * 
+     *
      * Sort an array of RemoteFiles
      */
     public static function sort($remote_files) {
@@ -83,7 +85,7 @@ class RemoteFile
 
     /**
      * Serialize
-     * 
+     *
      * Serialize an array of RemoteFiles so that they can be converted to JSON
      */
     public static function serialize($remoteFiles, $dateFormat="Y-m-d") {

--- a/src/helpers/RemoteFile.php
+++ b/src/helpers/RemoteFile.php
@@ -35,6 +35,8 @@ class RemoteFile
 
     public function __construct($filename, $size)
     {
+        Craft::info("Creating remote file object from path: ".$filename, "remote-core");
+
         // Extract values from filename
         preg_match(RemoteFile::$regex, $filename, $matches);
         if (count($matches) <= 0) {

--- a/src/services/ProviderService.php
+++ b/src/services/ProviderService.php
@@ -534,9 +534,11 @@ abstract class ProviderService extends Component implements ProviderInterface
      */
     protected function filterByExtension($remote_files, $extension)
     {
+        Craft::info("Filtering files by extension: " . $extension, "remote-core");
         $filtered_remote_files = [];
         foreach ($remote_files as $remote_file) {
             if (substr($remote_file->filename, -strlen($extension)) === $extension) {
+                Craft::info($remote_file->filename . " (flitered)", "remote-core");
                 array_push($filtered_remote_files, $remote_file);
             }
         }

--- a/src/services/ProviderService.php
+++ b/src/services/ProviderService.php
@@ -468,7 +468,11 @@ abstract class ProviderService extends Component implements ProviderInterface
         }
 
         $filename = ($systemName ? $systemName . '__' : '') . ($systemEnv ? $systemEnv . '__' : '') . gmdate('ymd_His') . '__' . strtolower(StringHelper::randomString(10)) . '__' . $currentVersion;
-        return mb_strtolower($filename);
+        $filename = mb_strtolower($filename);
+
+        Craft::info("Creating file name: ".$filename, "remote-core");
+
+        return $filename;
     }
 
     /**

--- a/src/services/ProviderService.php
+++ b/src/services/ProviderService.php
@@ -538,7 +538,7 @@ abstract class ProviderService extends Component implements ProviderInterface
         $filtered_remote_files = [];
         foreach ($remote_files as $remote_file) {
             if (substr($remote_file->filename, -strlen($extension)) === $extension) {
-                Craft::info($remote_file->filename . " (flitered)", "remote-core");
+                Craft::info($remote_file->filename . " (filtered)", "remote-core");
                 array_push($filtered_remote_files, $remote_file);
             }
         }

--- a/src/services/providers/AWSProvider.php
+++ b/src/services/providers/AWSProvider.php
@@ -15,11 +15,11 @@ use weareferal\remotecore\helpers\RemoteFile;
 
 /**
  * AWS Provider
- * 
+ *
  * A provider for use with Amazon AWS S3. This class can also be used to
  * implement other providers that use the S3 API footproint, like Digital
  * Ocean.
- * 
+ *
  * @since 1.0.0
  */
 class AWSProvider extends ProviderService
@@ -28,7 +28,7 @@ class AWSProvider extends ProviderService
 
     /**
      * Provider is configured
-     * 
+     *
      * @return boolean whether this provider is properly configured
      * @since 1.1.0
      */
@@ -44,13 +44,14 @@ class AWSProvider extends ProviderService
 
     /**
      * Return S3 keys
-     * 
+     *
      * @param string $extension The file extension to filter the results by
      * @return array[string] An array of keys returned from S3
      * @since 1.0.0
      */
     public function list($filterExtension): array
     {
+        Craft::info("AWS: Listing files", "remote-core");
         $client = $this->getClient();
         $kwargs = [
             'Bucket' => $this->getBucketName(),
@@ -62,11 +63,13 @@ class AWSProvider extends ProviderService
 
         $files = $response['Contents'];
         if (!$files) {
+            Craft::info("AWS: No files exist", "remote-core");
             return [];
         }
 
         $remote_files = [];
         foreach ($files as $file) {
+            Craft::info("AWS: " . $file['Key'] . " (unflitered)", "remote-core");
             array_push($remote_files, new RemoteFile(basename($file['Key']), $file['Size']));
         }
 
@@ -79,7 +82,7 @@ class AWSProvider extends ProviderService
 
     /**
      * Push a file path to S3
-     *  
+     *
      * @param string $path The full filesystem path to file
      * @since 1.0.0
      */
@@ -89,9 +92,9 @@ class AWSProvider extends ProviderService
         $pathInfo = pathinfo($path);
         $key = $this->getPrefixedKey($pathInfo['basename']);
 
-        Craft::debug("AWS: Pushing file to provider", "remote-core");
-        Craft::debug("AWS: Local path: " . $path, "remote-core");
-        Craft::debug("AWS: Remote path: " . $key, "remote-core");
+        Craft::info("AWS: Pushing file to provider", "remote-core");
+        Craft::info("AWS: Local path: " . $path, "remote-core");
+        Craft::info("AWS: Remote path: " . $key, "remote-core");
 
         try {
             $uploader = new MultipartUploader($client, $path, [
@@ -106,7 +109,7 @@ class AWSProvider extends ProviderService
 
     /**
      * Pull a remote S3 file
-     * 
+     *
      * @since 1.0.0
      */
     public function pull($key, $localPath)
@@ -114,10 +117,10 @@ class AWSProvider extends ProviderService
         $client = $this->getClient();
         $key = $this->getPrefixedKey($key);
 
-        Craft::debug("AWS: Pulling file from provider", "remote-core");
-        Craft::debug("AWS: Remote path: " . $key, "remote-core");
-        Craft::debug("AWS: Local path: " . $localPath, "remote-core");
-    
+        Craft::info("AWS: Pulling file from provider", "remote-core");
+        Craft::info("AWS: Remote path: " . $key, "remote-core");
+        Craft::info("AWS: Local path: " . $localPath, "remote-core");
+
         try {
             $client->getObject([
                 'Bucket' => $this->getBucketName(),
@@ -133,7 +136,7 @@ class AWSProvider extends ProviderService
 
     /**
      * Delete a remote S3 key
-     * 
+     *
      * @since 1.0.0
      */
     public function delete($key)
@@ -156,7 +159,7 @@ class AWSProvider extends ProviderService
 
     /**
      * Return the AWS key, including any prefix folders
-     * 
+     *
      * @param string $key The key for the key
      * @return string The prefixed key
      * @since 1.0.0
@@ -171,7 +174,7 @@ class AWSProvider extends ProviderService
 
     /**
      * Return a useable S3 client object
-     * 
+     *
      * @return S3Client The S3 client object
      * @since 1.0.0
      */
@@ -194,8 +197,8 @@ class AWSProvider extends ProviderService
 
     /**
      * Get endpoint
-     * 
-     * If using a non-AWS endpoint (like Digital Ocean) we specify the 
+     *
+     * If using a non-AWS endpoint (like Digital Ocean) we specify the
      * endpoint used in the client here
      */
     protected function getEndpoint(): ?string
@@ -204,28 +207,28 @@ class AWSProvider extends ProviderService
     }
 
     protected function getAccessKey(): ?string {
-        return Craft::parseEnv($this->plugin->settings->s3AccessKey); 
+        return Craft::parseEnv($this->plugin->settings->s3AccessKey);
     }
 
     protected function getSecretKey(): ?string {
-        return Craft::parseEnv($this->plugin->settings->s3SecretKey); 
+        return Craft::parseEnv($this->plugin->settings->s3SecretKey);
     }
 
     protected function getRegionName(): ?string {
-        return Craft::parseEnv($this->plugin->settings->s3RegionName); 
+        return Craft::parseEnv($this->plugin->settings->s3RegionName);
     }
 
     protected function getBucketName(): ?string {
-        return Craft::parseEnv($this->plugin->settings->s3BucketName); 
+        return Craft::parseEnv($this->plugin->settings->s3BucketName);
     }
 
     protected function getBucketPath(): ?string {
-        return Craft::parseEnv($this->plugin->settings->s3BucketPath); 
+        return Craft::parseEnv($this->plugin->settings->s3BucketPath);
     }
 
     /**
      * Create a more user-friendly error message from AWS
-     * 
+     *
      * @param AwsException $exception The exception
      * @return string An client-friendly string
      * @since 1.0.0

--- a/src/services/providers/AWSProvider.php
+++ b/src/services/providers/AWSProvider.php
@@ -51,7 +51,6 @@ class AWSProvider extends ProviderService
      */
     public function list($filterExtension): array
     {
-        Craft::info("AWS: Listing files", "remote-core");
         $client = $this->getClient();
         $kwargs = [
             'Bucket' => $this->getBucketName(),
@@ -69,7 +68,6 @@ class AWSProvider extends ProviderService
 
         $remote_files = [];
         foreach ($files as $file) {
-            Craft::info("AWS: " . $file['Key'] . " (unflitered)", "remote-core");
             array_push($remote_files, new RemoteFile(basename($file['Key']), $file['Size']));
         }
 
@@ -92,7 +90,6 @@ class AWSProvider extends ProviderService
         $pathInfo = pathinfo($path);
         $key = $this->getPrefixedKey($pathInfo['basename']);
 
-        Craft::info("AWS: Pushing file to provider", "remote-core");
         Craft::info("AWS: Local path: " . $path, "remote-core");
         Craft::info("AWS: Remote path: " . $key, "remote-core");
 
@@ -117,7 +114,6 @@ class AWSProvider extends ProviderService
         $client = $this->getClient();
         $key = $this->getPrefixedKey($key);
 
-        Craft::info("AWS: Pulling file from provider", "remote-core");
         Craft::info("AWS: Remote path: " . $key, "remote-core");
         Craft::info("AWS: Local path: " . $localPath, "remote-core");
 


### PR DESCRIPTION
## Fixed

- Updated the regex for filenames to include ' and _ (occasionally included in system names). See [Issue #19](https://github.com/weareferal/craft-remote-core/issues/19).

## Added

- Better handling of default environment when creating filename. See [Issue #54](https://github.com/weareferal/craft-remote-sync/issues/54).
- Additional logging to help with debugging user issues.
