### PR TITLE
Updated regex to fix file name issue and added IAM support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.1.2 - 2023-10-30
+
+### Fixed
+
+- Simplified the regex to accept all characters in the system name & env. Hopefully avoiding further interface errors. See [Issue #49](https://github.com/timmyomahony/craft-remote-backup/issues/49)
+
 ## 4.1.1 - 2023-09-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 4.1.2 - 2023-10-30
+## 4.1.2 - 2023-12-07
+
+### Added
+
+- Merged support for IAM profiles. See [Issue #44](https://github.com/timmyomahony/craft-remote-backup/issues/44).
 
 ### Fixed
 

--- a/src/helpers/RemoteFile.php
+++ b/src/helpers/RemoteFile.php
@@ -31,7 +31,7 @@ class RemoteFile
     //
     // https://regex101.com/r/yyAtKC/3
     private static $legacyRegex = '/^(?:[a-zA-Z0-9\-]+)\_(?:([a-zA-Z0-9\-]+)\_)?(\d{6}\_\d{6})\_(?:[a-zA-Z0-9]+)\_(?:([va-zA-Z0-9\.\-]+))\.(?:\w{2,10})$/';
-    private static $regex = '/^(?:[a-zA-Z0-9\_\-\']+)\_\_([a-zA-Z0-9\-]+)\_\_(\d{6}\_\d{6})\_\_(?:[a-zA-Z0-9]+)\_\_([va-zA-Z0-9\.\-]+)\.(?:\w{2,10})/';
+    private static $regex = '/^(?:.+)\_\_(.+)\_\_(\d{6}\_\d{6})\_\_(?:.+)\_\_([va-zA-Z0-9\.\-]+)\.(?:\w{2,10})/';
 
     public function __construct($filename, $size)
     {

--- a/src/helpers/RemoteFile.php
+++ b/src/helpers/RemoteFile.php
@@ -28,8 +28,6 @@ class RemoteFile
     // - Random string
     // - Version (captured)
     // - Extension
-    //
-    // https://regex101.com/r/yyAtKC/3
     private static $legacyRegex = '/^(?:[a-zA-Z0-9\-]+)\_(?:([a-zA-Z0-9\-]+)\_)?(\d{6}\_\d{6})\_(?:[a-zA-Z0-9]+)\_(?:([va-zA-Z0-9\.\-]+))\.(?:\w{2,10})$/';
     private static $regex = '/^(?:.+)\_\_(.+)\_\_(\d{6}\_\d{6})\_\_(?:.+)\_\_([va-zA-Z0-9\.\-]+)\.(?:\w{2,10})/';
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -7,7 +7,7 @@ use craft\base\Model;
 
 /**
  * Common plugin settings
- *  
+ *
  */
 abstract class Settings extends Model
 {
@@ -78,7 +78,7 @@ abstract class Settings extends Model
         return [
             // Provider details should only run when that provider is selected
             [
-                ['s3AccessKey', 's3SecretKey', 's3BucketName', 's3RegionName'],
+                ['s3BucketName', 's3RegionName'],
                 'required',
                 'when' => function ($model) {
                     return $model->cloudProvider == 's3' & $model->enabled == 1;
@@ -118,13 +118,13 @@ abstract class Settings extends Model
                 }
             ],
             [
-                ['otherS3AccessKey', 'otherS3SecretKey', 'otherS3BucketName', 'otherS3RegionName', 'otherS3Endpoint'],
+                ['otherS3BucketName', 'otherS3RegionName', 'otherS3Endpoint'],
                 'required',
                 'when' => function ($model) {
                     return $model->cloudProvider == 'other-s3' & $model->enabled == 1;
                 }
             ],
-            
+
             [
                 [
                     'cloudProvider',
@@ -141,7 +141,7 @@ abstract class Settings extends Model
                 ['useQueue', 'hideDatabases', 'hideVolumes'],
                 'boolean'
             ],
-            // This seems like a poor API design in Yii 2. We want to show a 
+            // This seems like a poor API design in Yii 2. We want to show a
             // validation when a user hides both the database and volumes. You
             //  can't create custom validators that run on two separate fields
             // (as it would run twice)

--- a/src/services/providers/AWSProvider.php
+++ b/src/services/providers/AWSProvider.php
@@ -34,11 +34,9 @@ class AWSProvider extends ProviderService
      */
     public function isConfigured(): bool
     {
-        $accessKey = $this->getAccessKey();
-        $secretKey = $this->getSecretKey();
+        $bucketName = $this->getBucketName();
         $regionName = $this->getRegionName();
-        return isset($accessKey) &&
-            isset($secretKey) &&
+        return isset($bucketName) &&
             isset($regionName);
     }
 
@@ -178,16 +176,18 @@ class AWSProvider extends ProviderService
     private function getClient(): S3Client
     {
         $options = [
-            'credentials' => array(
-                'key'    => $this->getAccessKey(),
-                'secret' => $this->getSecretKey()
-            ),
             'version' => 'latest',
             'region'  => $this->getRegionName()
         ];
         $endpoint = $this->getEndpoint();
         if ($endpoint) {
             $options['endpoint'] = $endpoint;
+        }
+        if ($this->getAccessKey() && $this->getSecretKey()) {
+            $options['credentials'] = [
+                'key'    => $this->getAccessKey(),
+                'secret' => $this->getSecretKey(),
+            ];
         }
         return S3Client::factory($options);
     }

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -41,7 +41,6 @@
         suggestEnvVars: true,
         suggestAliases: true,
         value: settings.s3AccessKey,
-        required: (settings.cloudProvider == 's3'),
         type: 'password',
         errors: settings.getErrors('s3AccessKey'),
         warning: configWarning('s3AccessKey', pluginHandle)
@@ -55,7 +54,6 @@
         suggestEnvVars: true,
         suggestAliases: true,
         value: settings.s3SecretKey,
-        required: (settings.cloudProvider == 's3'),
         type: 'password',
         errors: settings.getErrors('s3SecretKey'),
         warning: configWarning('s3SecretKey', pluginHandle)
@@ -241,7 +239,7 @@
         value: settings.googleDriveFolderId,
         errors: settings.getErrors('googleDriveFolderId'),
         warning: configWarning('googleDriveFolderId', pluginHandle)
-    }) }}    
+    }) }}
 
     {% if isConfigured and not isAuthenticated %}
         <div>


### PR DESCRIPTION
## Added

- Merged support for IAM profiles. See [Issue #44](https://github.com/timmyomahony/craft-remote-backup/issues/44).

## Fixed

- Simplified the regex to accept all characters in the system name & env. Hopefully avoiding further interface errors. See [Issue #49](https://github.com/timmyomahony/craft-remote-backup/issues/49)