### PR TITLE
Only consider standard storage class for AWSProvider

### DIFF
--- a/src/services/providers/AWSProvider.php
+++ b/src/services/providers/AWSProvider.php
@@ -66,7 +66,9 @@ class AWSProvider extends ProviderService
 
         $remote_files = [];
         foreach ($files as $file) {
-            array_push($remote_files, new RemoteFile(basename($file['Key']), $file['Size']));
+            if ($file['StorageClass'] == "STANDARD") {
+                array_push($remote_files, new RemoteFile(basename($file['Key']), $file['Size']));
+            }
         }
 
         if ($filterExtension) {


### PR DESCRIPTION
Refer [this issue](https://github.com/timmyomahony/craft-remote-backup/issues/54).

## The problem 

When calling `listObjects` in `AWSProvider.php` (e.g. as a result of clicking the "test connection" button), it's possible to have returned  two entries in `$response['Contents']`:

```
[
    {
        "Key": "remotebackup/",
        "LastModified": "2023-10-22 00:16:12.000000",
        "timezone_type": 2,
        "timezone": "Z",
        "ETag": "d41d8cd98f00b204e9800998ecf8427e",
        "Size": "0",
        "StorageClass": "GLACIER",
        "Owner": {
            "DisplayName": "mebooks.support",
            "ID": "51a1119ec3b864ef78e705b1d7de4d9ba6c248bcac06b5515573cf62b9c546ad"
        }
    },
    {
        "Key": "remotebackup/upgrade.5adayeducation.org.nz__production__231218_110657__nixsjmjmml__v4.5.13.sql",
        "LastModified": "2023-12-18 10:30:34.000000",
        "timezone_type": 2,
        "timezone": "Z",
        "ETag": "3c548f264b353f2730410f631e18d8fb",
        "Size": "281702",
        "StorageClass": "STANDARD",
        "Owner": {
            "DisplayName": "mebooks.support",
            "ID": "51a1119ec3b864ef78e705b1d7de4d9ba6c248bcac06b5515573cf62b9c546ad"
        }
    },
]
```

Note that in the above we have two entries, one which has `"StorageClass": "STANDARD"` and the other with `"StorageClass": "GLACIER"`.
In this case, the bucket had a policy to remove objects to Glacier storage after a certain period of time.

A response such as this this causes a failure in the constructor in `RemoteFile.php` as it doesn't match to `$regex`.

## The solution as per this PR

In this PR, we ensure that only results returned from the `listObjects` call that have `"StorageClass": "STANDARD"` are considered.

Doing this fixes the problem, with the "Test connection" button working as well as the "Backup Database" and "Backup Volumes" buttons working.

## How to reproduce the issue

* Create an S3 bucket that will contain the `remotebackup` folder with a lifecycle rule which transitions files to glacier storage (see below)
* You probably need to allow S3 the time to copy the (possibly empty) `remotebackup` folder to glacier storage
* Try the "Test connection" button in the UI -- you'll receive the following error:
<img width="1253" alt="image" src="https://github.com/timmyomahony/craft-remote-core/assets/851300/97eb092d-bf1d-4bcb-9f7f-3438a22be77f">


<img width="1201" alt="image" src="https://github.com/timmyomahony/craft-remote-core/assets/851300/6f6c5680-4303-462f-9a79-e82f1b40631c">

## Discussion

This solution effectively ignores any files that may have been transitioned to glacier storage. A fuller solution might involve applying the Prune Backups settings to any objects in Glacier storage.